### PR TITLE
Fix UAC elevation issue on 32bit windows

### DIFF
--- a/unitTestApp/src/Makefile
+++ b/unitTestApp/src/Makefile
@@ -45,13 +45,18 @@ OPCUA_OBJS += RecordConnector Session Subscription
 #==================================================
 # Build tests executables
 
-GTESTPROD_HOST += UpdateTest
-UpdateTest_SRCS += UpdateTest.cpp
-GTESTS += UpdateTest
+# with 32bit image on 64bit windows there is an issue with
+# program names that contain the word update in them in that they
+# automatically result in an admin prompt via UAC
+# This is due to Installer Detection Technology
+# See https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-vista/cc709628(v=ws.10)?redirectedfrom=MSDN
+GTESTPROD_HOST += UpdatTest
+UpdatTest_SRCS += UpdateTest.cpp
+GTESTS += UpdatTest
 
-GTESTPROD_HOST += UpdateQueueTest
-UpdateQueueTest_SRCS += UpdateQueueTest.cpp
-GTESTS += UpdateQueueTest
+GTESTPROD_HOST += UpdatQueueTest
+UpdatQueueTest_SRCS += UpdateQueueTest.cpp
+GTESTS += UpdatQueueTest
 
 GTESTPROD_HOST += RequestQueueBatcherTest
 RequestQueueBatcherTest_SRCS += RequestQueueBatcherTest.cpp


### PR DESCRIPTION
Fixes issue where running `UpdateTest` and `UpdateQueueTest` on 32bit jenkins build failed due to prompting for elevated access. This is due to "Installer Detection Technology" in UAC which is activated by filenames containing the word "Update"

See e.g.  https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/jj574202(v=ws.11)